### PR TITLE
Add LoggerFactory for structured logging

### DIFF
--- a/src/alvarium/logging/factories.py
+++ b/src/alvarium/logging/factories.py
@@ -1,0 +1,26 @@
+import logging
+import socket
+
+
+class LoggerFactory:
+    """A factory that returns a specific implementation of a Logger"""
+
+    def get_logger(self, name: str = __name__, level: int = logging.DEBUG) -> logging.Logger:
+        class LowerCaseLevelNameFormatter(logging.Formatter):
+            def format(self, record):
+                record.levelname = record.levelname.lower()
+                return super().format(record)
+            
+        logger = logging.getLogger(name)
+        logger.propagate = False
+        logging.basicConfig(level=level)
+
+        handler = logging.StreamHandler()
+        formatter = LowerCaseLevelNameFormatter('{"timestamp":"%(asctime)s","log-level": "%(levelname)s","message":"%(message)s","hostname":"%(hostname)s", "application":"%(filename)s", "line-number":"%(filename)s:%(lineno)d"}', 
+                                      datefmt='%Y-%m-%dT%H:%M:%SZ',
+                                      validate=True, 
+                                      defaults={'hostname': socket.gethostname()} )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        return logger

--- a/tests/example/__main__.py
+++ b/tests/example/__main__.py
@@ -2,6 +2,8 @@
 import os
 import sys
 
+from alvarium.logging.factories import LoggerFactory
+
 PROJECT_PATH = os.getcwd()
 SOURCE_PATH = os.path.join(
     PROJECT_PATH,"src"
@@ -26,8 +28,7 @@ with open("./tests/example/sdk-config.json", "r") as file:
 sdk_info = SdkInfo.from_json(json.dumps(config["sdk"]))
 
 # construct logger
-logger = logging.getLogger(__name__)
-logging.basicConfig(level = logging.DEBUG)
+logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
 
 # construct annotators
 annotator_factory = AnnotatorFactory()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -4,6 +4,7 @@ from alvarium.contracts.config import SdkInfo
 from alvarium.annotators.factories import AnnotatorFactory
 from alvarium.sdk import Sdk
 from alvarium.default import DefaultSdk
+from alvarium.logging.factories import LoggerFactory
 
 class TestSdk(unittest.TestCase):
 
@@ -17,8 +18,7 @@ class TestSdk(unittest.TestCase):
         annotator_factory = AnnotatorFactory()
         annotators = [annotator_factory.get_annotator(kind=annotation_type, sdk_info=sdk_info) for annotation_type in sdk_info.annotators]
 
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level = logging.DEBUG)
+        logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
 
         sdk: Sdk = DefaultSdk(annotators=annotators,config=sdk_info,logger=logger)
         sdk.close()
@@ -28,8 +28,7 @@ class TestSdk(unittest.TestCase):
         annotator_factory = AnnotatorFactory()
         annotators = [annotator_factory.get_annotator(kind=annotation_type, sdk_info=sdk_info) for annotation_type in sdk_info.annotators]
 
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level = logging.DEBUG)
+        logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
         sdk = DefaultSdk(annotators=annotators, config=sdk_info, logger=logger)
 
         test_data = b'test'
@@ -41,8 +40,7 @@ class TestSdk(unittest.TestCase):
         annotator_factory = AnnotatorFactory()
         annotators = [annotator_factory.get_annotator(kind=annotation_type, sdk_info=sdk_info) for annotation_type in sdk_info.annotators]
 
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level = logging.DEBUG)
+        logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
         sdk = DefaultSdk(annotators=annotators, config=sdk_info, logger=logger)
 
         old_data = b'old data'
@@ -56,8 +54,7 @@ class TestSdk(unittest.TestCase):
         annotator_factory = AnnotatorFactory()
         annotators = [annotator_factory.get_annotator(kind=annotation_type, sdk_info=sdk_info) for annotation_type in sdk_info.annotators]
 
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level = logging.DEBUG)
+        logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
         sdk = DefaultSdk(annotators=annotators, config=sdk_info, logger=logger)
 
         test_data = b'test'
@@ -69,8 +66,7 @@ class TestSdk(unittest.TestCase):
         annotator_factory = AnnotatorFactory()
         annotators = [annotator_factory.get_annotator(kind=annotation_type, sdk_info=sdk_info) for annotation_type in sdk_info.annotators]
 
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level = logging.DEBUG)
+        logger = LoggerFactory().get_logger(name=__name__, level=logging.DEBUG)
 
         sdk = DefaultSdk(annotators=annotators, config=sdk_info, logger=logger)
 


### PR DESCRIPTION
Fix #10 

This PR introduces a new `LoggerFactory` class in `factories.py`. This class provides a method `get_logger` to create a logger with a custom format and behavior to output structured logs following the format in the [Go sdk PR](https://github.com/project-alvarium/alvarium-sdk-go/pull/46)
Key features of the `LoggerFactory` class include:

- The `get_logger` method, which creates a new logger with the specified name and log level. The log level defaults to `logging.DEBUG` if not provided and name to the default __name__ logger.
- A custom formatter `LowerCaseLevelNameFormatter` is used to convert the log level name to lowercase.
- The log format includes the timestamp, log level, message, hostname, application name (filename), and line number.
- The hostname is automatically populated using `socket.gethostname()`.

Example:
```{"timestamp":"2024-01-21T09:37:47Z","log-level": "debug","message":"sdk disposed","hostname":"DESKTOP-0QCUII1", "application":"default.py", "line-number":"default.py:63"}```